### PR TITLE
Corrigindo problema com o GitHub pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-pokemongovet.github.io


### PR DESCRIPTION
#66 @fititnt você precisa renomear o branch para master para que o ghpages reconheça o repositório como page. O arquivo CNAME é utilizado somente quando a página estiver em um domínio personalizado, como aqui ele vai estar em github.io ele não é necessário.