### PR TITLE
Inserindo cor nas listagens dos centros pokemon

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3867,6 +3867,7 @@
 	.listagem-place h3 {
 		margin: 0;
 		font-size: 1em;
+		color: #2E3842;
 	}
 	.listagem-place ul {
 		margin: 0;


### PR DESCRIPTION
Os nomes dos centros tinham ficado brancos e devido o background ser brancos ele não ficarão visiveis, mudei a cor para a que estava antes, portanto, problema resolvido.