### PR TITLE
Resolucao de bug: substituindo o redirecionamento para o link atual

### DIFF
--- a/sobre.html
+++ b/sobre.html
@@ -127,7 +127,7 @@
             <h3>Como entrar em contato</h3>
             <h4>Locais para adoção</h4>
             <p>Para entrar em contato com os "centro pokemon" (aka locais para adoção responsável de animais)
-              visite <a href="./adote-um-pokemon-realista.html">a página com a listagem de todos os cadastrados</a>.
+              visite <a href="./adote-um-pokemon-de-verdade.html">a página com a listagem de todos os cadastrados</a>.
               Não temos como falar em nome deles, porém se houver algum problema, pode entrar em contato
               para remover ou editar algum contato listado aqui.
             </p>


### PR DESCRIPTION
Na página sobre.html subistitui o link incorreto atribuido para a listagem de centro pokemon cadastrado de "./adote-um-pokemon-realista.html" para "./adote-um-pokemon-de-verdade.html" resolvendo a Issue #97 
