### PR TITLE
Corrigindo repetição da tag de fechamento label

### DIFF
--- a/indicar-centro-pokemon.html
+++ b/indicar-centro-pokemon.html
@@ -96,7 +96,6 @@
               Endereço
               <input type="text" name="endereco" id="endereco">
             </label>
-            </label>
             <label class="input-1-3" for="telefone">
               Telefone
               <input type="tel" name="telefone" id="telefone">


### PR DESCRIPTION
A tag de fechamento "label" do campo de endereço no formulário está duplicada
Eu apaguei uma para corrigir o erro