### PR TITLE
Adicionado novo seletor de input do tipo telefone

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1679,6 +1679,7 @@
 	input[type="text"],
 	input[type="password"],
 	input[type="email"],
+  input[type="tel"],
 	select,
 	textarea {
 		-moz-appearance: none;
@@ -1699,6 +1700,7 @@
 		input[type="text"]:invalid,
 		input[type="password"]:invalid,
 		input[type="email"]:invalid,
+    input[type="tel"]:invalid,
 		select:invalid,
 		textarea:invalid {
 			box-shadow: none;
@@ -1707,6 +1709,7 @@
 		input[type="text"]:focus,
 		input[type="password"]:focus,
 		input[type="email"]:focus,
+    input[type="tel"]:focus,
 		select:focus,
 		textarea:focus {
 			box-shadow: 0 0 0 2px #21b2a6;
@@ -1751,6 +1754,7 @@
 	input[type="text"],
 	input[type="password"],
 	input[type="email"],
+  input[type="tel"],
 	select {
 		height: 2.75em;
 	}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3016,6 +3016,7 @@
 			.wrapper.style5 input[type="text"],
 			.wrapper.style5 input[type="password"],
 			.wrapper.style5 input[type="email"],
+      .wrapper.style5 input[type="tel"],
 			.wrapper.style5 select,
 			.wrapper.style5 textarea {
 				background: rgba(0, 0, 0, 0.0375);


### PR DESCRIPTION
Quando foi atualizado o projeto com o PR #103 houve uma quebra de estilos no layout do formulário, pois o input adicionado não era selecionado para receber os estilos dos demais.
[![Image from Gyazo](https://i.gyazo.com/c86f241f8216577906301fb61d207484.png)](https://gyazo.com/c86f241f8216577906301fb61d207484)

Eu atualizei adicionando o seletor de input do tipo "tel" nos mesmo grupos de estilos dos outros campos do formulário.